### PR TITLE
Set up basic CI workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,36 @@
+## PR Build Workflow
+#
+# Build the project and execute all unit tests and static analysis checks.
+#
+# Runs when any new PR is created for merge into `main`, and then executes again after such a PR is merged, in order to
+# ensure that all checks continue to pass following integration.  Can also be executed manually, for any branch.
+
+name: 'Gradle Build'
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+
+      - name: 'Set Up Java'
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      - name: 'Set Up Gradle'
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: 'Build with Gradle'
+        run: ./gradlew check

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 tasks {
-    create("run", Exec::class.java) {
+    create("check", Exec::class.java) {
         commandLine("echo", "Hello, World!")
     }
 }


### PR DESCRIPTION
This is the same basic CI workflow we would expect to see for any Gradle project: build the project and run the tests for every PR.  Exactly which tests are run as part of the `check` task is left to `build.gradle.kts`; doing so minimizes the amount of build code that only runs on CI/CD and keeps the development feedback loop short.

Rename the "Hello, World" task from `run` to `check`, so that when we evolve the project into a set of Gradle plugins we won't need to modify the CI/CD workflow.

Defer the "CD" part of CI/CD until we have something that can be meaningfully deployed.