### PR TITLE
Skeleton of Kotlin convention plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # aph-gradle-conventions
 Gradle convention plugins for use in my own projects
+
+## Overview
+
+Defines Gradle convention plugins for use in various kinds of projects; see below for a brief description of each of
+them.  These are intended only for my own personal use and probably won't be of interest to others, but I intend to
+maintain basic semantic versioning practices in case, anyway.
+
+Each plugin is identified by its short name, which is also the Gradle module where it resides in this project.  To
+consume the plugin externally, use this Gradle plugin identifier:
+
+```kotlin
+plugins {
+    id("io.github.aaron-harris.gradle-conventions.<SHORT NAME>")
+}
+```
+
+## Plugin `aph-kotlin`
+
+A convention plugin for arbitrary Kotlin (JVM) projects.

--- a/aph-kotlin/build.gradle.kts
+++ b/aph-kotlin/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    `kotlin-dsl`
+    `maven-publish`
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(libs.kotlin.gradlePlugin)
+}
+
+group = "io.github.aaron-harris.gradle-conventions"
+
+// Used for local development only; published versions should be overridden in CI/CD
+version = "local-SNAPSHOT"

--- a/aph-kotlin/src/main/kotlin/io.github.aaron-harris.gradle-conventions.aph-kotlin.gradle.kts
+++ b/aph-kotlin/src/main/kotlin/io.github.aaron-harris.gradle-conventions.aph-kotlin.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("kotlin")
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,0 @@
-tasks {
-    create("check", Exec::class.java) {
-        commandLine("echo", "Hello, World!")
-    }
-}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,5 @@
+[versions]
+kotlin = "2.0.0"
+
+[libraries]
+kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,3 @@
 rootProject.name = "aph-gradle-conventions"
+
+include("aph-kotlin")


### PR DESCRIPTION
Create a new convention plugin for arbitrary Kotlin projects.  This initial version simply wraps the standard Kotlin language plugin (and therefore encapsulates the Kotlin language version to use); I will first sort out concerns like publishing for cross-repository usage, and then expand it to include things like static analysis tools.

Since I will be publishing this plugin to GitHub Packages, it makes sense to use `io.github.aaron-harris` as the base for my Gradle coordinates, both for the plugin itself and for the group identifier of its implementation artifact.  Note that because my GitHub username includes a hyphen, the "path" part of the plugin identifier cannot be expressed as a JVM package, so in order to get the right ID I needed to include the whole thing in the filename.

The actual configuration to publish the plugin to GitHub Packages is not present yet, but by publishing it to my Maven Local repository, I was able to confirm that it is built correctly and can be consumed by external projects under the expected identifier.