### PR TITLE
Configure Ktlint for plugin build

### DIFF
--- a/aph-kotlin/build.gradle.kts
+++ b/aph-kotlin/build.gradle.kts
@@ -1,6 +1,10 @@
+import com.diffplug.gradle.spotless.BaseKotlinExtension
+
 plugins {
     `kotlin-dsl`
     `maven-publish`
+
+    alias(libs.plugins.spotless)
 }
 
 repositories {
@@ -15,3 +19,18 @@ group = "io.github.aaron-harris.gradle-conventions"
 
 // Used for local development only; published versions should be overridden in CI/CD
 version = "local-SNAPSHOT"
+
+spotless {
+    val sharedKtlint: BaseKotlinExtension.() -> Unit = {
+        ktlint(libs.versions.ktlint.get())
+            .setEditorConfigPath("$rootDir/.editorconfig")
+    }
+
+    kotlin {
+        sharedKtlint()
+        targetExclude("build/**/*.kt")
+    }
+    kotlinGradle {
+        sharedKtlint()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,10 @@
 [versions]
 kotlin = "2.0.0"
+ktlint = "1.3.0"
+spotless = "6.25.0"
 
 [libraries]
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+
+[plugins]
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }


### PR DESCRIPTION
Add configuration to use the Ktlint linter for the build of the `aph-kotlin` plugin itself.  This applies both to the plugin source code (under `aph-kotlin/src`) and to the plugin's own build script (`aph-kotlin/build.gradle.kts`).  It does not apply to downstream projects that consume the plugin, nor to the root module's build scripts (such as `settings.gradle.kts`).