### PR TITLE
Configure Ktlint in `aph-kotlin` plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,8 @@ plugins {
 ## Plugin `aph-kotlin`
 
 A convention plugin for arbitrary Kotlin (JVM) projects.
+
+Contains the following functionality:
+ - Automatic linting (using [Ktlint](https://pinterest.github.io/ktlint/latest/)), both for the consuming project's 
+   sources and for its `build.gradle.kts` file.  Linting rules can be customized through `.editorconfig` in the usual
+   way.

--- a/aph-kotlin/build.gradle.kts
+++ b/aph-kotlin/build.gradle.kts
@@ -14,6 +14,7 @@ repositories {
 
 dependencies {
     implementation(libs.kotlin.gradlePlugin)
+    implementation(libs.spotless.gradlePlugin)
 }
 
 group = "io.github.aaron-harris.gradle-conventions"

--- a/aph-kotlin/src/main/kotlin/io.github.aaron-harris.gradle-conventions.aph-kotlin.gradle.kts
+++ b/aph-kotlin/src/main/kotlin/io.github.aaron-harris.gradle-conventions.aph-kotlin.gradle.kts
@@ -1,3 +1,22 @@
+import com.diffplug.gradle.spotless.BaseKotlinExtension
+import com.diffplug.gradle.spotless.SpotlessExtension
+
 plugins {
     id("kotlin")
+
+    id("com.diffplug.spotless")
+}
+
+configure<SpotlessExtension> {
+    val sharedKtlint: BaseKotlinExtension.() -> Unit = {
+        ktlint("1.3.0")
+            .setEditorConfigPath("$rootDir/.editorconfig")
+    }
+
+    kotlin {
+        sharedKtlint()
+    }
+    kotlinGradle {
+        sharedKtlint()
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ spotless = "6.25.0"
 
 [libraries]
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+spotless-gradlePlugin = { group = "com.diffplug.spotless", name = "spotless-plugin-gradle", version.ref = "spotless" }
 
 [plugins]
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }


### PR DESCRIPTION
Configure Ktlint as a linter again, but this time for downstream consumers of the `aph-kotlin` plugin.

The version of Ktlint is currently hard-coded at 1.3.0.  This is the same version used in the plugin build itself, but because it needs to be specified in the plugin source itself, linking the two versions is challenging.  We can't reference the version catalog here because the catalog resolved will be that of the consuming project, not this one. The best long-term approach may be to leave the two references separate, but add a test to verify that they remain in sync, as discussed in [this blog post](https://lukeplant.me.uk/blog/posts/keeping-things-in-sync-derive-vs-test/). That will entail learning Gradle's plugin-testing tools, though, so let's leave that alone for now.

More specific Ktlint configuration (such as disabled rules) is governed by the consuming project's `.editorconfig` file and is not specified here.

Note that I am avoiding use of `spotless` as a type-safe accessor in the plugin source here, using `configure<SpotlessExtension>` instead.  This is because my IDE (IntelliJ 2024.1.4) can't recognize `spotless` without an explicit import of the generated accessor, which should not be necessary.  Gradle itself compiles the plugin fine, so I believe this is an IDE bug only, but better to avoid type-safe accessors until it is fixed.