### PR TITLE
Configure Detekt in `aph-kotlin` plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,6 @@ Contains the following functionality:
  - Automatic linting (using [Ktlint](https://pinterest.github.io/ktlint/latest/)), both for the consuming project's 
    sources and for its `build.gradle.kts` file.  Linting rules can be customized through `.editorconfig` in the usual
    way.
+ - Static analysis using [Detekt](https://detekt.dev/), both for the consuming project's sources and for its
+   `build.gradle.kts` file.  Rules can be customized by providing a Detekt configuration file in the usual way and in
+   the default location (`config/detekt/detekt.yaml`, relative to the project's root directory).

--- a/aph-kotlin/build.gradle.kts
+++ b/aph-kotlin/build.gradle.kts
@@ -15,6 +15,7 @@ repositories {
 dependencies {
     implementation(libs.kotlin.gradlePlugin)
     implementation(libs.spotless.gradlePlugin)
+    implementation(libs.detekt.gradlePlugin)
 }
 
 group = "io.github.aaron-harris.gradle-conventions"

--- a/aph-kotlin/src/main/kotlin/io.github.aaron-harris.gradle-conventions.aph-kotlin.gradle.kts
+++ b/aph-kotlin/src/main/kotlin/io.github.aaron-harris.gradle-conventions.aph-kotlin.gradle.kts
@@ -1,10 +1,12 @@
 import com.diffplug.gradle.spotless.BaseKotlinExtension
 import com.diffplug.gradle.spotless.SpotlessExtension
+import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 
 plugins {
     id("kotlin")
 
     id("com.diffplug.spotless")
+    id("io.gitlab.arturbosch.detekt")
 }
 
 configure<SpotlessExtension> {
@@ -19,4 +21,12 @@ configure<SpotlessExtension> {
     kotlinGradle {
         sharedKtlint()
     }
+}
+
+configure<DetektExtension> {
+    source.setFrom(
+        "src/main/kotlin",
+        "src/test/kotlin",
+        "build.gradle.kts",
+    )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ ktlint = "1.3.0"
 spotless = "6.25.0"
 
 [libraries]
+detekt-gradlePlugin = { group = "io.gitlab.arturbosch.detekt", name = "detekt-gradle-plugin", version.ref = "detekt" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
 spotless-gradlePlugin = { group = "com.diffplug.spotless", name = "spotless-plugin-gradle", version.ref = "spotless" }
 


### PR DESCRIPTION
Configure Ktlint for static analysis again, this time for downstream consumers of the `aph-kotlin` plugin.

As with Ktlint, rules configuration is left to the consuming project. Projects that do not have a Detekt configuration file in the expected location will be checked against Detekt's default ruleset.