### PR TITLE
Add configuration for unit tests and code coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,15 @@ plugins {
 A convention plugin for arbitrary Kotlin (JVM) projects.
 
 Contains the following functionality:
+ - Common configuration for things like unit tests that I expect to be configured in the same way across all my Kotlin
+   projects.
  - Automatic linting (using [Ktlint](https://pinterest.github.io/ktlint/latest/)), both for the consuming project's 
    sources and for its `build.gradle.kts` file.  Linting rules can be customized through `.editorconfig` in the usual
    way.
  - Static analysis using [Detekt](https://detekt.dev/), both for the consuming project's sources and for its
    `build.gradle.kts` file.  Rules can be customized by providing a Detekt configuration file in the usual way and in
    the default location (`config/detekt/detekt.yaml`, relative to the project's root directory).
+ - Code coverage using [Kover](https://github.com/Kotlin/kotlinx-kover).  Coverage is automatically calculated and
+   reported to the console as part of the `check` task, and an HTML report is also generated.  No minimum is currently
+   enforced, but that is planned for the near future.  Consuming projects can make their own additional changes in
+   `build.gradle.kts` using the `kover` extension.

--- a/aph-kotlin/build.gradle.kts
+++ b/aph-kotlin/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation(libs.kotlin.gradlePlugin)
     implementation(libs.spotless.gradlePlugin)
     implementation(libs.detekt.gradlePlugin)
+    implementation(libs.kover.gradlePlugin)
 }
 
 group = "io.github.aaron-harris.gradle-conventions"

--- a/aph-kotlin/src/main/kotlin/io.github.aaron-harris.gradle-conventions.aph-kotlin.gradle.kts
+++ b/aph-kotlin/src/main/kotlin/io.github.aaron-harris.gradle-conventions.aph-kotlin.gradle.kts
@@ -1,12 +1,15 @@
 import com.diffplug.gradle.spotless.BaseKotlinExtension
 import com.diffplug.gradle.spotless.SpotlessExtension
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
+import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
+import org.gradle.api.tasks.testing.logging.TestLogEvent
 
 plugins {
     id("kotlin")
 
     id("com.diffplug.spotless")
     id("io.gitlab.arturbosch.detekt")
+    id("org.jetbrains.kotlinx.kover")
 }
 
 configure<SpotlessExtension> {
@@ -29,4 +32,25 @@ configure<DetektExtension> {
         "src/test/kotlin",
         "build.gradle.kts",
     )
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+
+    testLogging {
+        events(
+            TestLogEvent.PASSED,
+            TestLogEvent.SKIPPED,
+            TestLogEvent.FAILED,
+            TestLogEvent.STANDARD_OUT,
+            TestLogEvent.STANDARD_ERROR,
+        )
+    }
+}
+
+configure<KoverProjectExtension> {
+    reports.total {
+        log.onCheck = true
+        html.onCheck = true
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,14 @@
 [versions]
 detekt = "1.23.6"
 kotlin = "2.0.0"
+kover = "0.8.1"
 ktlint = "1.3.0"
 spotless = "6.25.0"
 
 [libraries]
 detekt-gradlePlugin = { group = "io.gitlab.arturbosch.detekt", name = "detekt-gradle-plugin", version.ref = "detekt" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+kover-gradlePlugin = { group = "org.jetbrains.kotlinx", name = "kover-gradle-plugin", version.ref = "kover" }
 spotless-gradlePlugin = { group = "com.diffplug.spotless", name = "spotless-plugin-gradle", version.ref = "spotless" }
 
 [plugins]


### PR DESCRIPTION
Include my default configuration for unit tests (mostly concerned with ensuring that unit test output is visible in the console), and add configuration to use the Kover plugin for measuring code coverage.

Since we expect consuming projects to need to set their own coverage thresholds, do not include that configuration yet.  The next step is to create a plugin extension for `aph-kotlin` that will include that as a configurable property.  This will allow us to set a default in a way that can be overridden by consuming projects, and without the consuming project having any knowledge of Kover's configuration DSL.