### PR TITLE
Add default repository configuration to `aph-kotlin` plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ plugins {
 A convention plugin for arbitrary Kotlin (JVM) projects.
 
 Contains the following functionality:
- - Common configuration for things like unit tests that I expect to be configured in the same way across all my Kotlin
-   projects.
+ - Common configuration for things like repositories and unit tests that I expect to be configured in the same way 
+   across all my Kotlin projects.
  - Automatic linting (using [Ktlint](https://pinterest.github.io/ktlint/latest/)), both for the consuming project's 
    sources and for its `build.gradle.kts` file.  Linting rules can be customized through `.editorconfig` in the usual
    way.

--- a/aph-kotlin/src/main/kotlin/io.github.aaron-harris.gradle-conventions.aph-kotlin.gradle.kts
+++ b/aph-kotlin/src/main/kotlin/io.github.aaron-harris.gradle-conventions.aph-kotlin.gradle.kts
@@ -12,6 +12,10 @@ plugins {
     id("org.jetbrains.kotlinx.kover")
 }
 
+repositories {
+    mavenCentral()
+}
+
 configure<SpotlessExtension> {
     val sharedKtlint: BaseKotlinExtension.() -> Unit = {
         ktlint("1.3.0")


### PR DESCRIPTION
Include Maven Central as a repository for all consuming projects.