### PR TITLE
Add DSL extension for the `aph-kotlin` plugin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+[*.kt]
+# My GitHub name includes a hyphen, so if I want to use an io.github package name, convention says to use underscore,
+# which this rule forbids.  Disable it in favor of Detekt, which provides a more-flexible version of the same rule.
+ktlint_standard_package-name = disabled

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A convention plugin for arbitrary Kotlin (JVM) projects.
 Contains the following functionality:
  - Common configuration for things like repositories and unit tests that I expect to be configured in the same way 
    across all my Kotlin projects.
+ - A plugin configuration DSL accessible in `build.gradle.kts` via the `aphKotlin` extension.
  - Automatic linting (using [Ktlint](https://pinterest.github.io/ktlint/latest/)), both for the consuming project's 
    sources and for its `build.gradle.kts` file.  Linting rules can be customized through `.editorconfig` in the usual
    way.
@@ -30,6 +31,14 @@ Contains the following functionality:
    `build.gradle.kts` file.  Rules can be customized by providing a Detekt configuration file in the usual way and in
    the default location (`config/detekt/detekt.yaml`, relative to the project's root directory).
  - Code coverage using [Kover](https://github.com/Kotlin/kotlinx-kover).  Coverage is automatically calculated and
-   reported to the console as part of the `check` task, and an HTML report is also generated.  No minimum is currently
-   enforced, but that is planned for the near future.  Consuming projects can make their own additional changes in
-   `build.gradle.kts` using the `kover` extension.
+   reported to the console as part of the `check` task, and an HTML report is also generated.  By default, a minimum of
+   80% line coverage is required, but consuming projects can modify or waive this requirement using the plugin's 
+   extension DSL.
+
+Example configuration:
+
+```kotlin
+aphKotlin {
+    codeCoverage.minimumRequired = 75
+}
+```

--- a/aph-kotlin/src/main/kotlin/io.github.aaron-harris.gradle-conventions.aph-kotlin.gradle.kts
+++ b/aph-kotlin/src/main/kotlin/io.github.aaron-harris.gradle-conventions.aph-kotlin.gradle.kts
@@ -1,5 +1,6 @@
 import com.diffplug.gradle.spotless.BaseKotlinExtension
 import com.diffplug.gradle.spotless.SpotlessExtension
+import io.github.aaron_harris.gradle.kotlin.AphKotlinExtension
 import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
 import org.gradle.api.tasks.testing.logging.TestLogEvent
@@ -11,6 +12,13 @@ plugins {
     id("io.gitlab.arturbosch.detekt")
     id("org.jetbrains.kotlinx.kover")
 }
+
+val aphKotlin =
+    project.extensions.create<AphKotlinExtension>(AphKotlinExtension.EXTENSION_NAME).apply {
+        extensions.create<AphKotlinExtension.CodeCoverage>(AphKotlinExtension.CodeCoverage.EXTENSION_NAME).apply {
+            minimumRequired.convention(AphKotlinExtension.CodeCoverage.Defaults.MINIMUM_REQUIRED)
+        }
+    }
 
 repositories {
     mavenCentral()
@@ -53,8 +61,14 @@ tasks.withType<Test> {
 }
 
 configure<KoverProjectExtension> {
-    reports.total {
-        log.onCheck = true
-        html.onCheck = true
+    reports {
+        verify.rule {
+            minBound(aphKotlin.codeCoverage.minimumRequired)
+        }
+
+        total {
+            log.onCheck = true
+            html.onCheck = true
+        }
     }
 }

--- a/aph-kotlin/src/main/kotlin/io/github/aaron_harris/gradle/kotlin/AphKotlinExtension.kt
+++ b/aph-kotlin/src/main/kotlin/io/github/aaron_harris/gradle/kotlin/AphKotlinExtension.kt
@@ -1,0 +1,58 @@
+package io.github.aaron_harris.gradle.kotlin
+
+import org.gradle.api.Action
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.api.provider.Property
+import org.gradle.kotlin.dsl.getByType
+
+@DslMarker
+annotation class AphKotlinGradlePluginDsl
+
+/**
+ * DSL extension for the `aph-kotlin` convention plugin.
+ *
+ * Example of configuration:
+ *
+ * ```
+ * aphKotlin {
+ *     codeCoverage {
+ *         minimumRequired = 75
+ *     }
+ * }
+ * ```
+ */
+@AphKotlinGradlePluginDsl
+interface AphKotlinExtension : ExtensionAware {
+    val codeCoverage: CodeCoverage get() = extensions.getByType()
+
+    fun codeCoverage(block: Action<CodeCoverage>) {
+        block.execute(codeCoverage)
+    }
+
+    /** Sub-extension of `aphKotlin` for settings related to code coverage. */
+    @AphKotlinGradlePluginDsl
+    interface CodeCoverage {
+        /**
+         * The minimum amount of code coverage (in terms of lines) that should be required.
+         *
+         * The `check` task will fail if this threshold is not met.
+         *
+         * Set to zero to effectively disable code coverage requirements.
+         *
+         * Defaults to [Defaults.MINIMUM_REQUIRED].
+         */
+        val minimumRequired: Property<Int>
+
+        object Defaults {
+            const val MINIMUM_REQUIRED = 80
+        }
+
+        companion object {
+            internal const val EXTENSION_NAME = "codeCoverage"
+        }
+    }
+
+    companion object {
+        internal const val EXTENSION_NAME = "aphKotlin"
+    }
+}

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -75,7 +75,7 @@ comments:
     matchDeclarationsOrder: true
     allowParamOnConstructorProperties: false
   UndocumentedPublicClass:
-    active: true
+    active: false
     excludes:
       - '**/test/**'
     searchInNestedClass: true
@@ -84,12 +84,12 @@ comments:
     searchInInnerInterface: true
     searchInProtectedClass: false
   UndocumentedPublicFunction:
-    active: true
+    active: false
     excludes:
       - '**/test/**'
     searchProtectedFunction: false
   UndocumentedPublicProperty:
-    active: true
+    active: false
     excludes:
       - '**/test/**'
     searchProtectedProperty: false
@@ -372,7 +372,7 @@ naming:
     privatePropertyPattern: '(_)?[A-Za-z][_A-Za-z0-9]*'
   PackageNaming:
     active: true
-    packagePattern: '[a-z]+(\.[a-z][A-Za-z0-9]*)*'
+    packagePattern: 'io\.github\.aaron_harris(\.[a-z][A-Za-z0-9]*)*'
   TopLevelPropertyNaming:
     active: true
     constantPattern: '[A-Z][_A-Z0-9]*'


### PR DESCRIPTION
This extension currently contains a single configurable property, for the minimum code coverage threshold that should be required.

The point of making this configurable is to allow consuming projects to set the threshold without needing to know about the details of how to do so using Kover's DSL, or in fact even whether code coverage is being measured by Kover or Jacoco.  Also, I'm pretty sure that Kover's verification rules are additive, meaning that the alternative approach of just setting a rule in the convention plugin and expecting consuming projects to be able to override it using Kover's DSL would not work as desired.

Even though there's only a single property, structure the extension hierarchically by function area in an attempt to allow for future expansion.