### PR TITLE
Add configuration property for excluding classes from code coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Example configuration:
 
 ```kotlin
 aphKotlin {
-    codeCoverage.minimumRequired = 75
+    codeCoverage { 
+        minimumRequired = 75
+        excludedClasses.add("foo.BarKt")
+    }
 }
 ```

--- a/aph-kotlin/src/main/kotlin/io.github.aaron-harris.gradle-conventions.aph-kotlin.gradle.kts
+++ b/aph-kotlin/src/main/kotlin/io.github.aaron-harris.gradle-conventions.aph-kotlin.gradle.kts
@@ -66,6 +66,8 @@ configure<KoverProjectExtension> {
             minBound(aphKotlin.codeCoverage.minimumRequired)
         }
 
+        filters.excludes.classes = aphKotlin.codeCoverage.excludedClasses
+
         total {
             log.onCheck = true
             html.onCheck = true

--- a/aph-kotlin/src/main/kotlin/io/github/aaron_harris/gradle/kotlin/AphKotlinExtension.kt
+++ b/aph-kotlin/src/main/kotlin/io/github/aaron_harris/gradle/kotlin/AphKotlinExtension.kt
@@ -3,6 +3,7 @@ package io.github.aaron_harris.gradle.kotlin
 import org.gradle.api.Action
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.gradle.kotlin.dsl.getByType
 
 @DslMarker
@@ -17,6 +18,7 @@ annotation class AphKotlinGradlePluginDsl
  * aphKotlin {
  *     codeCoverage {
  *         minimumRequired = 75
+ *         excludedClasses.add("foo.BarKt")
  *     }
  * }
  * ```
@@ -42,6 +44,14 @@ interface AphKotlinExtension : ExtensionAware {
          * Defaults to [Defaults.MINIMUM_REQUIRED].
          */
         val minimumRequired: Property<Int>
+
+        /**
+         * Classes that should be excluded from the code coverage requirement.
+         *
+         * Values may include glob wildcards; see [kotlinx.kover.gradle.plugin.dsl.KoverReportFilter.classes] for more
+         * details.
+         */
+        val excludedClasses: SetProperty<String>
 
         object Defaults {
             const val MINIMUM_REQUIRED = 80


### PR DESCRIPTION
This is a more-or-less transparent wrapper around Kover's equivalent property, and using its DSL is not particularly onerous, so the primary benefit of this is simply API consistency: a consuming project should not have to configure code coverage settings in two places.  This does also shield consuming projects from knowing about Kover at all, though, so there may also be some benefit in case we eventually want to change code coverage plugins.