### PR TITLE
Create CI/CD workflow for publishing to GitHub Packages

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,37 @@
+## Publishing Workflow
+#
+# Build the project and push the resulting artifacts to GitHub Packages.
+#
+# Runs whenever a new GitHub Release is created.  The version of the published artifact will be the same as that of the
+# triggering GitHub Release.
+
+name: 'Publish to GitHub Packages'
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v4
+
+      - name: 'Set Up Java'
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 17
+
+      - name: 'Set Up Gradle'
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: 'Build with Gradle'
+        run: >-
+          ./gradlew
+          -Pversion={{ github.ref }}
+          -PgitHubRepoUrl="https://maven.pkg.github.com/{{ github.repository }}"
+          -PgitHubUser={{ github.actor }}
+          -PgitHubToken={{ github.token }}
+          check publish

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ plugins {
 }
 ```
 
+All plugins are published to the GitHub Packages repository associated with this project.
+
 ## Plugin `aph-kotlin`
 
 A convention plugin for arbitrary Kotlin (JVM) projects.

--- a/aph-kotlin/build.gradle.kts
+++ b/aph-kotlin/build.gradle.kts
@@ -19,11 +19,6 @@ dependencies {
     implementation(libs.kover.gradlePlugin)
 }
 
-group = "io.github.aaron-harris.gradle-conventions"
-
-// Used for local development only; published versions should be overridden in CI/CD
-version = "local-SNAPSHOT"
-
 spotless {
     val sharedKtlint: BaseKotlinExtension.() -> Unit = {
         ktlint(libs.versions.ktlint.get())
@@ -44,4 +39,23 @@ detekt {
         "src/main/kotlin",
         "build.gradle.kts",
     )
+}
+
+publishing {
+    val gitHubRepoUrl: String? by project
+    gitHubRepoUrl?.let { repoUrl ->
+        val gitHubUser: String by project
+        val gitHubToken: String by project
+
+        repositories {
+            maven {
+                name = "GitHubPackages"
+                url = uri(repoUrl)
+                credentials {
+                    username = gitHubUser
+                    password = gitHubToken
+                }
+            }
+        }
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+group=io.github.aaron-harris.gradle-conventions
+
+# Version used for local publishing only; should be overridden when publishing in CI/CD.
+version=local-SNAPSHOT


### PR DESCRIPTION
This is my first attempt to use GitHub Packages, so I am not expecting that this will work on the first try.  Nevertheless, I would rather debug it post-merge, in CI/CD, rather than trying to also figure out how to get it to work locally so I can debug it ahead of time.

Because we want the version specified for a CI/CD release to override the "local-SNAPSHOT" version used for local development, we must either move the local definition of the `version` property to a different location (since specifying it directly in `build.gradle.kts` is higher-priority than a command-line specification), or else have the CI/CD version be specified indirectly (say, as an environment variable) and explicitly construct the version in `build.gradle.kts` using the Elvis operator.  I've opted for the former, as it seems more straightforward, and moved `version` to a `gradle.properties` file. Move the `group` too, since it's related and not complicated in its handling.

Note that the version identifier for the published artifact will be taken directly from the GitHub release creating it.  This implies that release tags should be exactly identical to the semantic versions they name, and in particular should not use the "v" prefix that is sometimes suggested.  A quick look at some authoritative Kotlin projects didn't turn up any that use the "v", so this seems to be the majority view.