### PR TITLE
Inject data for publishing using GitHub Actions environment

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,10 +28,15 @@ jobs:
         uses: gradle/actions/setup-gradle@v3
 
       - name: 'Build and Publish'
+        env:
+          VERSION: ${{ github.ref }}
+          GITHUB_REPO_URL: "https://maven.pkg.github.com/${{ github.repository }}"
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: >-
           ./gradlew
-          -Pversion=${{ github.ref }}
-          -PgitHubRepoUrl="https://maven.pkg.github.com/${{ github.repository }}"
-          -PgitHubUser=${{ github.actor }}
-          -PgitHubToken=${{ github.token }}
+          -Pversion="$VERSION"
+          -PgitHubRepoUrl="$GITHUB_REPO_URL"
+          -PgitHubUser="$GITHUB_USER"
+          -PgitHubToken="$GITHUB_TOKEN"
           check publish


### PR DESCRIPTION
I just noticed that GitHub's docs
[say](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable) to avoid injecting data elements directly into an inline script, due to concerns about script injection.  I don't think I'm particularly vulnerable here, since any attacker would have to first be able to create a GitHub release in my repository, and I'm not planning on granting anyone other than myself write access.  But it's a good practice that I should adopt anyway.