### PR TITLE
Use correct version identifier in publishing workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: 'Build and Publish'
         env:
-          VERSION: ${{ github.ref }}
+          VERSION: ${{ github.ref_name }}
           GITHUB_REPO_URL: "https://maven.pkg.github.com/${{ github.repository }}"
           GITHUB_USER: ${{ github.actor }}
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Publishing is failing because the version being supplied is the long ref of the tag ("/refs/tags/1.0.0"), rather than the short ref we are expecting ("1.0.0").  Swapping `github.ref_name` for `github.ref` should do what we want.