### PR TITLE
Give publishing workflow permission to write to GitHub Packages

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -14,6 +14,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v4


### PR DESCRIPTION
This is an attempt to address the permissions issue encountered in [this failing workflow](https://github.com/aaron-harris/aph-gradle-conventions/actions/runs/9782599158/job/27009286172).